### PR TITLE
Killtracer: monitors kernel debug traces for signals

### DIFF
--- a/killtracer/.gitignore
+++ b/killtracer/.gitignore
@@ -1,0 +1,1 @@
+killtracer

--- a/killtracer/TraceKillEnabler.go
+++ b/killtracer/TraceKillEnabler.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	//"bufio"
+	"fmt"
+	"github.com/opendns/lemming/lib/log"
+	"io/ioutil"
+	//"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const TraceKillEnterEnable string = "/sys/kernel/debug/tracing/events/syscalls/sys_enter_kill/enable"
+const TraceKillExitEnable string = "/sys/kernel/debug/tracing/events/syscalls/sys_exit_kill/enable"
+
+// Delay in the KillTraceEnabler's check of whether the values are still on
+const TraceKillWatchPollTime = 10 * time.Second
+
+// getKernelToggle reads the value of a kernel toggle and returns it as an int.
+// If error is non-nil then something went wrong trying to read it and the
+// returned value is meaningless.
+//
+func getKernelToggle(file string) (int, error) {
+	valStr, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Warning("Could not read contents of `%s': %v", file, err)
+		return -1, err
+	}
+	// Get old value
+	val, err := strconv.Atoi(strings.TrimSpace(string(valStr)))
+	if err != nil {
+		log.Warning("Could not parse contents of `%s' into an int: %v", file, err)
+		return -1, err
+	}
+	return val, nil
+}
+
+// setKernelToggle writes the given value to the supplied file.  If err is non-
+// nil then something went wrong and it was probably not set.
+//
+func setKernelToggle(file string, val int) error {
+	log.Info("Writing `%d` to `%s'", val, file)
+	if err := ioutil.WriteFile(file, []byte(fmt.Sprintf("%d", val)), 0644); err != nil {
+		log.Warning("Could not write `%d' to `%s': %v", val, file, err)
+		return err
+	}
+	return nil
+}
+
+// enableKernelToggle writes the given integer to the given file.  If the
+// supplied *int is non-nil, it will read the old value and save it there.
+// Helper function for KillTraceEnabler.Enable.
+//
+func enableKernelToggle(file string, old *int) error {
+	if old != nil {
+		val, err := getKernelToggle(file)
+		if err != nil {
+			return err
+		}
+		log.Info("Old value of `%s' was %d", file, val)
+		*old = val
+	}
+	return setKernelToggle(file, 1)
+}
+
+type KillTraceEnabler struct {
+	oldEnterValue int
+	oldExitValue  int
+	done          chan int
+}
+
+// NewKillTraceEnabler initializes and returns a KillTraceEnabler struct.
+//
+func NewKillTraceEnabler() *KillTraceEnabler {
+	var e KillTraceEnabler
+	e.done = make(chan int)
+	return &e
+}
+
+// Enables kernel syscall tracing for the kill system call, both entry and
+// exit.  Stores the old values.
+//
+func (e *KillTraceEnabler) Enable() {
+	if enableKernelToggle(TraceKillEnterEnable, &e.oldEnterValue) != nil {
+		log.Error("Could not enable syscall_kill entry tracing; are you root?") // panics
+	}
+	if enableKernelToggle(TraceKillExitEnable, &e.oldExitValue) != nil {
+		log.Error("Could not enable syscall_kill exit tracing; are you root?") // panics
+	}
+}
+
+// Restores kernel syscall tracing to the previous values.
+//
+func (e *KillTraceEnabler) Disable() {
+	if setKernelToggle(TraceKillEnterEnable, e.oldEnterValue) != nil {
+		log.Warning("Failed to restore syscall_kill entry tracing to old value (%d)", e.oldEnterValue)
+	}
+	if setKernelToggle(TraceKillExitEnable, e.oldExitValue) != nil {
+		log.Warning("Failed to restore syscall_kill exit tracing to old value (%d)", e.oldExitValue)
+	}
+}
+
+// Watches the values of the syscall_kill entry and exit trace flags.  If they
+// are disabled, will re-enable them and log a warning.  Does not exit until
+// the EndWatch() method is called.
+//
+func (e *KillTraceEnabler) Watch() {
+	for {
+		select {
+		case <-e.done:
+			// Somebody called EndWatch()
+			return
+		default:
+			// carry on
+		}
+
+		enterTrace, err := getKernelToggle(TraceKillEnterEnable)
+		if err != nil {
+			log.Warning("Watcher can't read `%s': %v", TraceKillEnterEnable, err)
+			continue
+		}
+		exitTrace, err := getKernelToggle(TraceKillExitEnable)
+		if err != nil {
+			log.Warning("Watcher can't read `%s': %v", TraceKillExitEnable, err)
+			continue
+		}
+		if enterTrace == 0 || exitTrace == 0 {
+			log.Warning("Something disabled syscall_kill tracing! (entry = %d, exit = %d)  Re-enabling", enterTrace, exitTrace)
+			if enableKernelToggle(TraceKillEnterEnable, nil) != nil {
+				log.Error("Could not re-enable syscall_kill entry tracing!") // panics
+			}
+			if enableKernelToggle(TraceKillExitEnable, nil) != nil {
+				log.Error("Could not re-enable syscall_kill exit tracing!") // panics
+			}
+		}
+		log.Debug("Watcher: syscall_kill enter/exit tracing still enabled; sleeping %d seconds", TraceKillWatchPollTime/time.Second)
+		time.Sleep(TraceKillWatchPollTime)
+	}
+
+}
+
+// Signals the Watch() goroutine to exit.
+//
+func (e *KillTraceEnabler) EndWatch() {
+	e.done <- 1
+}

--- a/killtracer/WatchTracePipe.go
+++ b/killtracer/WatchTracePipe.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/opendns/lemming/lib/log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const TracePipe = "/sys/kernel/debug/tracing/trace_pipe"
+
+/* The output of trace_pipe is a never-ending stream.  It looks like this:
+ *
+ *            who-21651 [001] .... 1299466.655190: sys_kill(pid: 45db, sig: 0)
+ *            who-21651 [001] .... 1299466.655197: sys_kill -> 0x0
+ */
+
+// Entry regexp:
+//   $1 -> signalling process binary (base 10)
+//   $2 -> signalling process id (base 16)
+//   $3 -> target process id (base 16)
+//   $4 -> signal system call return value (base 16)
+var entryRegexp = regexp.MustCompile(`\s*(\w+)-(\d+).*?: sys_kill\(pid: ([0-9a-f]+), sig: ([0-9a-f]+)`)
+
+// Exit regex:
+//   $1 -> signalling binary (base 10)
+//   $2 -> signalling process id (base 16)
+//   $3 -> signal return value (base 16, 0 = success as per the manpage for (2)kill
+var exitRegexp = regexp.MustCompile(`\s*(\w+)-(\d+).*?: sys_kill -> 0x([0-9a-f]+)`)
+
+func WatchTracePipe() {
+	tracePipeReader, err := os.Open(TracePipe)
+	if err != nil {
+		log.Error("Could not open `%s': %v", TracePipe, err) // panics
+	}
+	tp := bufio.NewReader(tracePipeReader)
+	for {
+		line, err := tp.ReadString('\n')
+		if err != nil {
+			// Attempt to reopen once -- during testing I saw at
+			// least one EINTR, so this might be necessary (erbarret)
+			log.Warning("Got error reading trace_pipe: %v", err)
+			tracePipeReader.Close()
+			tracePipeReader, err := os.Open(TracePipe)
+			if err != nil {
+				log.Error("Could not reopen `%s': %v", TracePipe, err) // panics
+			}
+			tp = bufio.NewReader(tracePipeReader)
+		}
+		log.Debug("Got trace_pipe line: %s", strings.TrimSpace(line))
+		matches := entryRegexp.FindStringSubmatch(line)
+		if matches != nil {
+			log.Debug("Looks like a syscall_kill entry line")
+			parseEntryMatch(matches)
+		}
+		matches = exitRegexp.FindStringSubmatch(line)
+		if matches != nil {
+			log.Debug("Looks like a syscall_kill exit line")
+			parseExitMatch(matches)
+		}
+	}
+}
+
+// hexToDec returns the given hex (base-16) string as decimal.  If the conversion fails,
+// returns the original string.
+func hexToDec(v string) string {
+	value, err := strconv.ParseInt(v, 16, 0)
+	if err == nil {
+		return fmt.Sprintf("%d", value)
+	} else {
+		return v
+	}
+}
+
+func parseEntryMatch(matches []string) {
+	log.Info("Saw kill from %s (pid %s), signal target pid %s, signal value %s", matches[1], matches[2], hexToDec(matches[3]), hexToDec(matches[4]))
+}
+
+func parseExitMatch(matches []string) {
+	log.Info("Signal by %s (pid %s) had return value %s", matches[1], matches[2], hexToDec(matches[3]))
+}

--- a/killtracer/main.go
+++ b/killtracer/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/opendns/lemming/lib/log"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	signal.Ignore(syscall.SIGWINCH)
+	e := NewKillTraceEnabler()
+	log.Info("Enabling syscall_kill tracing")
+	e.Enable()
+	defer e.Disable()
+	log.Info("Starting syscall_kill trace watcher thread")
+	go e.Watch()
+
+	log.Info("Watching trace pipe for kill signals")
+	WatchTracePipe()
+
+	log.Info("Restoring old syscall_kill tracing values")
+	e.EndWatch()
+}


### PR DESCRIPTION
Needs some more work (UID of offending process, ignoring signal 0) but it's got basic functionality.
