### PR TITLE
Refactor anonymous goroutine in testSomeLogMethod

### DIFF
--- a/lib/log/log_test.go
+++ b/lib/log/log_test.go
@@ -72,10 +72,10 @@ func testSomeLogMethod(t *testing.T, fn LogMethod, level string, expectOutput bo
 
 	// Generate log message
 	rs := randomString()
-	go func() {
+	go func(fn LogMethod, rs string, w io.WriteCloser) {
 		fn(rs)
 		w.Close()
-	}()
+	}(fn, rs, w)
 
 	// Check we got the message
 	var output []byte = make([]byte, 1024)


### PR DESCRIPTION
This method was panicking on some systems due to an I/O deadlock in the goroutine writing the log message to an io.Pipe.  Change the goroutine to use args instead of being a closure to see if this will help.
